### PR TITLE
Added health to scarecrow's reflection shieldd

### DIFF
--- a/Player Files/OLD_Zero/SwordHitbox.gd
+++ b/Player Files/OLD_Zero/SwordHitbox.gd
@@ -14,6 +14,7 @@ func enemy_touched(obj):
 		#print(String(OS.get_ticks_msec())+" Bullet reflected!")
 		#reflectSound.play()
 		print("Sword Reflected.")
+		# TODO: Need to drain reflection health like bullets...?
 		pass
 	else:
 		if obj.has_method("damage"):

--- a/Player Files/Weapons/ArchiRocket_Player.gd
+++ b/Player Files/Weapons/ArchiRocket_Player.gd
@@ -77,6 +77,7 @@ func enemy_touched_alt(obj,reflect):
 	if reflect:
 		print("Reflected")
 		reflected=true
+		try_drain_reflection_health(obj)
 		#print(String(OS.get_ticks_msec())+" Bullet reflected!")
 		reflectSound.play()
 		killSelf(false,true)
@@ -85,6 +86,9 @@ func enemy_touched_alt(obj,reflect):
 			obj.call("damage",3,Globals.Weapons.Architect)
 		killSelf()
 
+func try_drain_reflection_health(obj):
+	if obj.has_method("drain_reflection_health"):
+		obj.call("drain_reflection_health",3,Globals.Weapons.Architect)
 
 #We want an isAlive var so we can play the death animation only one time
 var isAlive = true

--- a/Player Files/Weapons/WpnSnake.gd
+++ b/Player Files/Weapons/WpnSnake.gd
@@ -64,10 +64,16 @@ func enemy_touched_alt(obj,reflect):
 			self.rotation_degrees*=-1
 			$Sprite.flip_h=dir==1
 			cooldown=.1
+			# TODO: Damage to reflection shields should be done differently...?
+			try_drain_reflection_health(obj)
 	else:
 		if obj.has_method("damage"):
 			obj.call("damage",2,Globals.Weapons.Ouroboros)
 		killSelf()
+		
+func try_drain_reflection_health(obj):
+	if obj.has_method("drain_reflection_health"):
+		obj.call("drain_reflection_health",2,Globals.Weapons.Ouroboros)
 
 func killSelf(silent:bool=false):
 	var e = smallExplosion.instance()

--- a/Player Files/Weapons/bullet.gd
+++ b/Player Files/Weapons/bullet.gd
@@ -57,6 +57,7 @@ func enemy_touched_alt(obj,reflect):
 	#TODO: This doesn't account for damage types or effectiveness or whatever...
 	if reflect:
 		reflected=true
+		try_drain_reflection_health(obj)
 		#print(String(OS.get_ticks_msec())+" Bullet reflected!")
 		reflectSound.play()
 		#if obj.has_method("add_collision_exception_with"):
@@ -74,3 +75,7 @@ func enemy_touched_alt(obj,reflect):
 		if obj.has_method("damage"):
 			obj.call("damage",1,damageType)
 		queue_free()
+
+func try_drain_reflection_health(obj):
+	if obj.has_method("drain_reflection_health"):
+		obj.call("drain_reflection_health",1,damageType)

--- a/README.md
+++ b/README.md
@@ -1,21 +1,25 @@
 # Reina-Chan
+
 A Girls' Frontline fangame by the fans, for the fans.
 
 Oh, and it has a bunch of stolen music and sprites from Mega Man.
 
 ## Setup
-Download Godot 3.3.4 standard edition and read the instruction manual
 
-https://docs.google.com/document/d/1EfAIfdQKhDUkxr-qL31A7LX3hxD3qbjcuyv2UeUFb_A/edit#heading=h.66m1d64prb3g
+Download Godot 3.5.3 standard edition and read the instruction manual
+
+<https://docs.google.com/document/d/1EfAIfdQKhDUkxr-qL31A7LX3hxD3qbjcuyv2UeUFb_A/edit#heading=h.66m1d64prb3g>
 
 ## Releases
-The latest game demo is available at https://amaryllis-works.itch.io/reina-chan
+
+The latest game demo is available at <https://amaryllis-works.itch.io/reina-chan>
 
 A "release" will also be created here for the source code when a new demo comes out.
 
 ## License
+
 GPLv3 except for cutscene handling code from RepliCant which is CC-BY-NC-SA (Similar to GPL, but noncommercial).
 
-This game uses translated code from https://github.com/piulin/piured-engine which is also GPLv3
+This game uses translated code from <https://github.com/piulin/piured-engine> which is also GPLv3
 
-Game controller images from https://thoseawesomeguys.com/prompts/, CC0.
+Game controller images from <https://thoseawesomeguys.com/prompts/>, CC0.

--- a/Stages_Reina/Bosses/Scarecrow/BossScarecrow.gd
+++ b/Stages_Reina/Bosses/Scarecrow/BossScarecrow.gd
@@ -40,8 +40,13 @@ var player:KinematicBody2D
 
 var startingPosition:Vector2
 var topLeft:Vector2
+
+## Represents how much damage to be done to the reflection shield,
+## before reflection is turned off....
+var reflection_health = 0
+
 func _ready():
-	is_reflecting=true
+	_activate_reflection()
 	if get_parent().get_parent().is_class("Node2D"):
 		topLeft = get_parent().get_parent().global_position
 	startingPosition=self.position
@@ -155,7 +160,6 @@ func _physics_process(delta):
 				fireBullet()
 				shots+=1
 		STATE.IDLE:
-			is_reflecting=true
 			facing=DIRECTION.LEFT if global_position.x > player.global_position.x else DIRECTION.RIGHT
 			sprite.flip_h=(facing==DIRECTION.LEFT)
 			spinnyFrame.set_flipped(sprite.flip_h)
@@ -185,6 +189,7 @@ func _physics_process(delta):
 				idleTime=1
 				spinnyFrame.set_return_circling()
 				curState=STATE.IDLE
+				_activate_reflection()
 		STATE.SHOOT_SPREAD_INIT:
 			is_reflecting=false
 			spinnyFrame.set_float_to_top_spread((topLeft/64+Vector2(10,2))*64)
@@ -248,6 +253,7 @@ func _physics_process(delta):
 				spinnyFrame.set_return_circling(1.0,2.0)
 				idleTime=3.0
 				curState=STATE.IDLE
+				_activate_reflection()
 		STATE.GROUND_ATTACK_1:
 			#DUDE I JUST LOVE HOW THE BITS ARE 1-INDEXED IN THE GUI
 			#BUT 0-INDEXED WHEN USING THE COMMAND BECAUSE THAT
@@ -275,6 +281,7 @@ func _physics_process(delta):
 				get_parent().get_node("DustCloud").position=position
 				get_parent().get_node("DustCloud/AnimationPlayer").play("default")
 				curState=STATE.IDLE
+				_activate_reflection()
 				set_collision_layer_bit(1,true)
 				#set_collision_mask_bit(4,true)
 		#STATE.RETURN_CIRCLING:
@@ -284,3 +291,17 @@ func _physics_process(delta):
 	#Not sure why this isn't working automatically, because
 	#_physics_process can't normally be overridden (godot will execute both)
 	._physics_process(delta)
+
+func _activate_reflection():
+	is_reflecting = true
+	# TODO: Set by difficulty....
+	reflection_health = 6
+
+## NOTE: Don't rename, used by bullets to call...
+func drain_reflection_health(damage: int, damage_type: int):
+	# TODO: Different interaction based on damage type...
+	reflection_health -= damage
+	if reflection_health <= 0 && is_reflecting:
+		# TODO: play sound, or something...
+		is_reflecting = false
+		print("REFLECTION BROKEN")

--- a/Stages_Reina/Bosses/Scarecrow/BossScarecrow.tscn
+++ b/Stages_Reina/Bosses/Scarecrow/BossScarecrow.tscn
@@ -29,6 +29,18 @@ region = Rect2( 32, 0, 32, 43 )
 atlas = ExtResource( 8 )
 region = Rect2( 64, 0, 32, 43 )
 
+[sub_resource type="AtlasTexture" id=2]
+atlas = ExtResource( 5 )
+region = Rect2( 68, 0, 34, 36 )
+
+[sub_resource type="AtlasTexture" id=3]
+atlas = ExtResource( 5 )
+region = Rect2( 34, 0, 34, 36 )
+
+[sub_resource type="AtlasTexture" id=4]
+atlas = ExtResource( 5 )
+region = Rect2( 0, 0, 34, 36 )
+
 [sub_resource type="AtlasTexture" id=5]
 atlas = ExtResource( 2 )
 region = Rect2( 0, 0, 32, 46 )
@@ -49,18 +61,6 @@ region = Rect2( 96, 0, 32, 46 )
 atlas = ExtResource( 2 )
 region = Rect2( 128, 0, 32, 46 )
 
-[sub_resource type="AtlasTexture" id=2]
-atlas = ExtResource( 5 )
-region = Rect2( 68, 0, 34, 36 )
-
-[sub_resource type="AtlasTexture" id=3]
-atlas = ExtResource( 5 )
-region = Rect2( 34, 0, 34, 36 )
-
-[sub_resource type="AtlasTexture" id=4]
-atlas = ExtResource( 5 )
-region = Rect2( 0, 0, 34, 36 )
-
 [sub_resource type="SpriteFrames" id=10]
 animations = [ {
 "frames": [ SubResource( 1 ) ],
@@ -73,15 +73,15 @@ animations = [ {
 "name": "idle",
 "speed": 5.0
 }, {
-"frames": [ SubResource( 5 ), SubResource( 6 ), SubResource( 7 ), SubResource( 8 ), SubResource( 9 ), SubResource( 9 ) ],
-"loop": false,
-"name": "intro",
-"speed": 13.0
-}, {
 "frames": [ SubResource( 2 ), SubResource( 3 ), SubResource( 4 ), SubResource( 3 ) ],
 "loop": true,
 "name": "idle-o",
 "speed": 5.0
+}, {
+"frames": [ SubResource( 5 ), SubResource( 6 ), SubResource( 7 ), SubResource( 8 ), SubResource( 9 ), SubResource( 9 ) ],
+"loop": false,
+"name": "intro",
+"speed": 13.0
 } ]
 
 [node name="BossScarecrow" instance=ExtResource( 1 )]

--- a/project.godot
+++ b/project.godot
@@ -39,6 +39,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/godot-next/references/bitset.gd"
 }, {
+"base": "KinematicBody2D",
+"class": "BossBase",
+"language": "GDScript",
+"path": "res://Stages_Reina/Bosses/BossBase.gd"
+}, {
 "base": "Reference",
 "class": "CSVFile",
 "language": "GDScript",
@@ -84,7 +89,12 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/godot-next/global/editor_tools.gd"
 }, {
-"base": "Node",
+"base": "KinematicBody2D",
+"class": "EnemyBase",
+"language": "GDScript",
+"path": "res://Stages/EnemyBaseScript.gd"
+}, {
+"base": "",
 "class": "FLMusicLib",
 "language": "NativeScript",
 "path": "res://gdnative/FLMusicLib/FLMusic.gdns"
@@ -138,6 +148,11 @@ _global_script_classes=[ {
 "class": "MessageDispatcherWrapper",
 "language": "GDScript",
 "path": "res://addons/godot-next/nodes/message_dispatcher_wrapper.gd"
+}, {
+"base": "StaticBody2D",
+"class": "MiniBoss",
+"language": "GDScript",
+"path": "res://Stages/MinibossScript.gd"
 }, {
 "base": "Reference",
 "class": "PIURED_ID",
@@ -266,6 +281,7 @@ _global_script_class_icons={
 "Behavior": "",
 "BitFlag": "",
 "Bitset": "",
+"BossBase": "",
 "CSVFile": "",
 "CallbackDelegator": "",
 "CheatCodeDetector": "",
@@ -275,6 +291,7 @@ _global_script_class_icons={
 "Def": "",
 "DiscreteGradientTexture": "",
 "EditorTools": "",
+"EnemyBase": "",
 "FLMusicLib": "",
 "FileSearch": "",
 "FileSystemLink": "",
@@ -286,6 +303,7 @@ _global_script_class_icons={
 "MenuManager": "",
 "MessageDispatcher": "",
 "MessageDispatcherWrapper": "",
+"MiniBoss": "",
 "PIURED_ID": "",
 "PhysicsLayers": "",
 "PlayerGrenadeThrower": "",


### PR DESCRIPTION
Title;

Scarecrow's reflection shield can now be broken.

> Currently, set to health of 6, but we should dynamically set it based on difficulty?

Player's Bullets, Rocket and Snake will now try to call `drain_reflection_health` on objects if they are reflected.

> Currently, melee weapons are not being updated to handle calling `drain_reflection_health`

Fully tested on Stage 4 (scarecrow's stage), doesn't seem to break interaction with other enemies...

---

**P.S** Might refactor further in the future to make a `ReflectionComponent` node, and just have `BaseBoss` and `BaseEnemy` have it.

